### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/cases/esbuild-three/src/base/loaders/ImageLoader.js
+++ b/cases/esbuild-three/src/base/loaders/ImageLoader.js
@@ -71,7 +71,7 @@ ImageLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 		image.addEventListener( 'load', onImageLoad, false );
 		image.addEventListener( 'error', onImageError, false );
 
-		if ( url.substr( 0, 5 ) !== 'data:' ) {
+		if ( url.slice( 0, 5 ) !== 'data:' ) {
 
 			if ( this.crossOrigin !== undefined ) image.crossOrigin = this.crossOrigin;
 

--- a/cases/esbuild-three/src/base/loaders/LoaderUtils.js
+++ b/cases/esbuild-three/src/base/loaders/LoaderUtils.js
@@ -44,7 +44,7 @@ var LoaderUtils = {
 
 		if ( index === - 1 ) return './';
 
-		return url.substr( 0, index + 1 );
+		return url.slice( 0, index + 1 );
 
 	}
 


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

### Breaking Changes

None

### Additional Info
