### PR TITLE
ci: set least-privilege permissions on workflow token

### DIFF
--- a/.github/workflows/compare.yml
+++ b/.github/workflows/compare.yml
@@ -12,6 +12,9 @@ on:
         default: "webpack@webpack/webpack#master"
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   bench:
     strategy:

--- a/.github/workflows/measure-all-cases.yml
+++ b/.github/workflows/measure-all-cases.yml
@@ -12,6 +12,9 @@ on:
         default: "2021-10-01"
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   bench:
     strategy:

--- a/.github/workflows/measure-date.yml
+++ b/.github/workflows/measure-date.yml
@@ -7,6 +7,9 @@ on:
         description: "Date to measure (yyyy-mm-dd)"
         default: "2021-01-01"
         required: true
+permissions:
+  contents: read
+
 jobs:
   bench:
     strategy:

--- a/.github/workflows/measure-historic.yml
+++ b/.github/workflows/measure-historic.yml
@@ -11,6 +11,9 @@ on:
         description: "Scenario to measure"
         default: "development-build"
         required: true
+permissions:
+  contents: read
+
 jobs:
   bench:
     strategy:


### PR DESCRIPTION
Each of these workflows runs without a top-level `permissions:` block, so its `GITHUB_TOKEN` inherits the repository (or org) default, which is frequently read/write for all scopes.

Setting `contents: read` explicitly on `.github/workflows/compare.yml`, `.github/workflows/measure-all-cases.yml`, `.github/workflows/measure-date.yml`, `.github/workflows/measure-historic.yml` keeps the workflow token scoped to what the job actually uses. If a third-party action or transitive dependency in the run were ever compromised, a read-only token limits the damage (no pushes, no releases, no token-backed writes). The change is mechanical and does not alter any step.